### PR TITLE
iOS 12 updates

### DIFF
--- a/Pods/ObjectMapper/Sources/EnumOperators.swift
+++ b/Pods/ObjectMapper/Sources/EnumOperators.swift
@@ -30,11 +30,12 @@ public func >>> <T: RawRepresentable>(left: T?, right: Map) {
 	left >>> (right, EnumTransform())
 }
 
-
+/*
 /// Implicitly Unwrapped Optional Object of Raw Representable type
 public func <- <T: RawRepresentable>(left: inout T!, right: Map) {
 	left <- (right, EnumTransform())
 }
+*/
 
 // MARK:- Arrays of Raw Representable type
 
@@ -50,18 +51,19 @@ public func >>> <T: RawRepresentable>(left: [T], right: Map) {
 
 /// Array of Raw Representable object
 public func <- <T: RawRepresentable>(left: inout [T]?, right: Map) {
-	left <- (right, EnumTransform())
+    left <- (right, EnumTransform())
 }
 
 public func >>> <T: RawRepresentable>(left: [T]?, right: Map) {
 	left >>> (right, EnumTransform())
 }
 
-
+/*
 /// Array of Raw Representable object
-public func <- <T: RawRepresentable>(left: inout [T]!, right: Map) {
-	left <- (right, EnumTransform())
+public func <- <TA: RawRepresentable>(arr_left: inout [TA]!, arr_right: Map) {
+	arr_left <- (arr_right, EnumTransform())
 }
+*/
 
 // MARK:- Dictionaries of Raw Representable type
 
@@ -84,8 +86,10 @@ public func >>> <T: RawRepresentable>(left: [String: T]?, right: Map) {
 	left >>> (right, EnumTransform())
 }
 
-
+/*
 /// Dictionary of Raw Representable object
-public func <- <T: RawRepresentable>(left: inout [String: T]!, right: Map) {
-	left <- (right, EnumTransform())
+public func <- <T: RawRepresentable>(dict_left: inout [String: T]!, dict_right: Map) {
+	dict_left <- (dict_right, EnumTransform())
 }
+*/
+ 

--- a/Pods/ObjectMapper/Sources/EnumOperators.swift
+++ b/Pods/ObjectMapper/Sources/EnumOperators.swift
@@ -30,13 +30,6 @@ public func >>> <T: RawRepresentable>(left: T?, right: Map) {
 	left >>> (right, EnumTransform())
 }
 
-/*
-/// Implicitly Unwrapped Optional Object of Raw Representable type
-public func <- <T: RawRepresentable>(left: inout T!, right: Map) {
-	left <- (right, EnumTransform())
-}
-*/
-
 // MARK:- Arrays of Raw Representable type
 
 /// Array of Raw Representable object
@@ -58,13 +51,6 @@ public func >>> <T: RawRepresentable>(left: [T]?, right: Map) {
 	left >>> (right, EnumTransform())
 }
 
-/*
-/// Array of Raw Representable object
-public func <- <TA: RawRepresentable>(arr_left: inout [TA]!, arr_right: Map) {
-	arr_left <- (arr_right, EnumTransform())
-}
-*/
-
 // MARK:- Dictionaries of Raw Representable type
 
 /// Dictionary of Raw Representable object
@@ -85,11 +71,3 @@ public func <- <T: RawRepresentable>(left: inout [String: T]?, right: Map) {
 public func >>> <T: RawRepresentable>(left: [String: T]?, right: Map) {
 	left >>> (right, EnumTransform())
 }
-
-/*
-/// Dictionary of Raw Representable object
-public func <- <T: RawRepresentable>(dict_left: inout [String: T]!, dict_right: Map) {
-	dict_left <- (dict_right, EnumTransform())
-}
-*/
- 

--- a/Pods/ObjectMapper/Sources/FromJSON.swift
+++ b/Pods/ObjectMapper/Sources/FromJSON.swift
@@ -41,10 +41,10 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped optional basic type
-	class func optionalBasicType<FieldType>(_ field: inout FieldType!, object: FieldType?) {
-		field = object
+	class func optionalBasicType<FieldType>(_ field: inout FieldType!, iu_object: FieldType?) {
+		field = iu_object
 	}
-	
+ 
 	/// Mappable object
 	class func object<N: BaseMappable>(_ field: inout N, map: Map) {
 		if map.toObject {
@@ -65,11 +65,11 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped Optional Mappable Object
-	class func optionalObject<N: BaseMappable>(_ field: inout N!, map: Map) {
-		if let f = field , map.toObject && map.currentValue != nil {
-			field = Mapper(context: map.context).map(JSONObject: map.currentValue, toObject: f)
+	class func optionalObject<N: BaseMappable>(_ field: inout N!, inpl_map: Map) {
+		if let f = field , inpl_map.toObject && inpl_map.currentValue != nil {
+			field = Mapper(context: inpl_map.context).map(JSONObject: inpl_map.currentValue, toObject: f)
 		} else {
-			field = Mapper(context: map.context).map(JSONObject: map.currentValue)
+			field = Mapper(context: inpl_map.context).map(JSONObject: inpl_map.currentValue)
 		}
 	}
 	
@@ -91,8 +91,8 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectArray<N: BaseMappable>(_ field: inout Array<N>!, map: Map) {
-		if let objects: Array<N> = Mapper(context: map.context).mapArray(JSONObject: map.currentValue) {
+	class func optionalObjectArray<N: BaseMappable>(_ field: inout Array<N>!, inpl_map: Map) {
+		if let objects: Array<N> = Mapper(context: inpl_map.context).mapArray(JSONObject: inpl_map.currentValue) {
 			field = objects
 		} else {
 			field = nil
@@ -112,8 +112,8 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped optional 2 dimentional mappable object array
-	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(_ field: inout Array<Array<N>>!, map: Map) {
-		field = Mapper(context: map.context).mapArrayOfArrays(JSONObject: map.currentValue)
+	class func optionalTwoDimensionalObjectArray<N: BaseMappable>(_ field: inout Array<Array<N>>!, inpl_map: Map) {
+		field = Mapper(context: inpl_map.context).mapArrayOfArrays(JSONObject: inpl_map.currentValue)
 	}
 	
 	/// Dctionary containing Mappable objects
@@ -137,11 +137,11 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped Dictionary containing Mappable objects
-	class func optionalObjectDictionary<N: BaseMappable>(_ field: inout Dictionary<String, N>!, map: Map) {
-		if let f = field , map.toObject && map.currentValue != nil {
-			field = Mapper(context: map.context).mapDictionary(JSONObject: map.currentValue, toDictionary: f)
+	class func optionalObjectDictionary<N: BaseMappable>(_ field: inout Dictionary<String, N>!, inpl_map: Map) {
+		if let f = field , inpl_map.toObject && inpl_map.currentValue != nil {
+			field = Mapper(context: inpl_map.context).mapDictionary(JSONObject: inpl_map.currentValue, toDictionary: f)
 		} else {
-			field = Mapper(context: map.context).mapDictionary(JSONObject: map.currentValue)
+			field = Mapper(context: inpl_map.context).mapDictionary(JSONObject: inpl_map.currentValue)
 		}
 	}
 	
@@ -158,8 +158,8 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped Dictionary containing Array of Mappable objects
-	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(_ field: inout Dictionary<String, [N]>!, map: Map) {
-		field = Mapper<N>(context: map.context).mapDictionaryOfArrays(JSONObject: map.currentValue)
+	class func optionalObjectDictionaryOfArrays<N: BaseMappable>(_ field: inout Dictionary<String, [N]>!, inpl_map: Map) {
+		field = Mapper<N>(context: inpl_map.context).mapDictionaryOfArrays(JSONObject: inpl_map.currentValue)
 	}
 	
 	/// mappable object Set
@@ -175,7 +175,7 @@ internal final class FromJSON {
 	}
 	
 	/// Implicitly unwrapped optional mappable object array
-	class func optionalObjectSet<N: BaseMappable>(_ field: inout Set<N>!, map: Map) {
-		field = Mapper(context: map.context).mapSet(JSONObject: map.currentValue)
+	class func optionalObjectSet<N: BaseMappable>(_ field: inout Set<N>!, inpl_map: Map) {
+		field = Mapper(context: inpl_map.context).mapSet(JSONObject: inpl_map.currentValue)
 	}	
 }

--- a/Pods/ObjectMapper/Sources/IntegerOperators.swift
+++ b/Pods/ObjectMapper/Sources/IntegerOperators.swift
@@ -34,6 +34,7 @@ public func <- <T: SignedInteger>(left: inout T?, right: Map) {
 	}
 }
 
+/*
 /// ImplicitlyUnwrappedOptional SignedInteger mapping
 public func <- <T: SignedInteger>(left: inout T!, right: Map) {
 	switch right.mappingType {
@@ -45,7 +46,7 @@ public func <- <T: SignedInteger>(left: inout T!, right: Map) {
 	default: ()
 	}
 }
-
+*/
 
 // MARK: - Unsigned Integer
 
@@ -74,6 +75,7 @@ public func <- <T: UnsignedInteger>(left: inout T?, right: Map) {
 	}
 }
 
+/*
 /// ImplicitlyUnwrappedOptional UnsignedInteger mapping
 public func <- <T: UnsignedInteger>(left: inout T!, right: Map) {
 	switch right.mappingType {
@@ -85,6 +87,7 @@ public func <- <T: UnsignedInteger>(left: inout T!, right: Map) {
 	default: ()
 	}
 }
+ */
 
 // MARK: - Casting Utils
 

--- a/Pods/ObjectMapper/Sources/IntegerOperators.swift
+++ b/Pods/ObjectMapper/Sources/IntegerOperators.swift
@@ -34,20 +34,6 @@ public func <- <T: SignedInteger>(left: inout T?, right: Map) {
 	}
 }
 
-/*
-/// ImplicitlyUnwrappedOptional SignedInteger mapping
-public func <- <T: SignedInteger>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		let value: T! = toSignedInteger(right.currentValue)
-		FromJSON.basicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-*/
-
 // MARK: - Unsigned Integer
 
 /// UnsignedInteger mapping
@@ -74,20 +60,6 @@ public func <- <T: UnsignedInteger>(left: inout T?, right: Map) {
 	default: ()
 	}
 }
-
-/*
-/// ImplicitlyUnwrappedOptional UnsignedInteger mapping
-public func <- <T: UnsignedInteger>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		let value: T! = toUnsignedInteger(right.currentValue)
-		FromJSON.basicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
 
 // MARK: - Casting Utils
 

--- a/Pods/ObjectMapper/Sources/Operators.swift
+++ b/Pods/ObjectMapper/Sources/Operators.swift
@@ -370,15 +370,3 @@ public func >>> <T: BaseMappable>(left: Set<T>?, right: Map) {
 	}
 }
 
-/*
-/// Implicitly unwrapped Optional Set of Mappable objects
-public func <- <T: BaseMappable>(left: inout Set<T>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectSet(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */

--- a/Pods/ObjectMapper/Sources/Operators.swift
+++ b/Pods/ObjectMapper/Sources/Operators.swift
@@ -75,7 +75,7 @@ public func >>> <T>(left: T?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped optional object of basic type
 public func <- <T>(left: inout T!, right: Map) {
 	switch right.mappingType {
@@ -86,6 +86,7 @@ public func <- <T>(left: inout T!, right: Map) {
 	default: ()
 	}
 }
+ */
 
 // MARK:- Mappable Objects - <T: BaseMappable>
 
@@ -123,7 +124,7 @@ public func >>> <T: BaseMappable>(left: T?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped optional Mappable objects
 public func <- <T: BaseMappable>(left: inout T!, right: Map) {
 	switch right.mappingType {
@@ -134,6 +135,7 @@ public func <- <T: BaseMappable>(left: inout T!, right: Map) {
 	default: ()
 	}
 }
+ */
 
 // MARK:- Dictionary of Mappable objects - Dictionary<String, T: BaseMappable>
 
@@ -172,7 +174,7 @@ public func >>> <T: BaseMappable>(left: Dictionary<String, T>?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
 public func <- <T: BaseMappable>(left: inout Dictionary<String, T>!, right: Map) {
 	switch right.mappingType {
@@ -183,6 +185,7 @@ public func <- <T: BaseMappable>(left: inout Dictionary<String, T>!, right: Map)
 	default: ()
 	}
 }
+ */
 
 /// Dictionary of Mappable objects <String, T: Mappable>
 public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>, right: Map) {
@@ -218,7 +221,7 @@ public func >>> <T: BaseMappable>(left: Dictionary<String, [T]>?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
 public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>!, right: Map) {
 	switch right.mappingType {
@@ -229,6 +232,7 @@ public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>!, right: Ma
 	default: ()
 	}
 }
+ */
 
 // MARK:- Array of Mappable objects - Array<T: BaseMappable>
 
@@ -266,7 +270,7 @@ public func >>> <T: BaseMappable>(left: Array<T>?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional array of Mappable objects
 public func <- <T: BaseMappable>(left: inout Array<T>!, right: Map) {
 	switch right.mappingType {
@@ -277,6 +281,7 @@ public func <- <T: BaseMappable>(left: inout Array<T>!, right: Map) {
 	default: ()
 	}
 }
+ */
 
 // MARK:- Array of Array of Mappable objects - Array<Array<T: BaseMappable>>
 
@@ -315,7 +320,7 @@ public func >>> <T: BaseMappable>(left: Array<Array<T>>?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional array of Mappable objects
 public func <- <T: BaseMappable>(left: inout Array<Array<T>>!, right: Map) {
 	switch right.mappingType {
@@ -326,6 +331,7 @@ public func <- <T: BaseMappable>(left: inout Array<Array<T>>!, right: Map) {
 	default: ()
 	}
 }
+ */
 
 // MARK:- Set of Mappable objects - Set<T: BaseMappable>
 
@@ -364,7 +370,7 @@ public func >>> <T: BaseMappable>(left: Set<T>?, right: Map) {
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional Set of Mappable objects
 public func <- <T: BaseMappable>(left: inout Set<T>!, right: Map) {
 	switch right.mappingType {
@@ -375,3 +381,4 @@ public func <- <T: BaseMappable>(left: inout Set<T>!, right: Map) {
 	default: ()
 	}
 }
+ */

--- a/Pods/ObjectMapper/Sources/Operators.swift
+++ b/Pods/ObjectMapper/Sources/Operators.swift
@@ -75,19 +75,6 @@ public func >>> <T>(left: T?, right: Map) {
 	}
 }
 
-/*
-/// Implicitly unwrapped optional object of basic type
-public func <- <T>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalBasicType(&left, object: right.value())
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
-
 // MARK:- Mappable Objects - <T: BaseMappable>
 
 /// Object conforming to Mappable
@@ -123,19 +110,6 @@ public func >>> <T: BaseMappable>(left: T?, right: Map) {
 		ToJSON.optionalObject(left, map: right)
 	}
 }
-
-/*
-/// Implicitly unwrapped optional Mappable objects
-public func <- <T: BaseMappable>(left: inout T!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObject(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
 
 // MARK:- Dictionary of Mappable objects - Dictionary<String, T: BaseMappable>
 
@@ -174,19 +148,6 @@ public func >>> <T: BaseMappable>(left: Dictionary<String, T>?, right: Map) {
 	}
 }
 
-/*
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: BaseMappable>(left: inout Dictionary<String, T>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectDictionary(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
-
 /// Dictionary of Mappable objects <String, T: Mappable>
 public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>, right: Map) {
 	switch right.mappingType {
@@ -220,19 +181,6 @@ public func >>> <T: BaseMappable>(left: Dictionary<String, [T]>?, right: Map) {
 		ToJSON.optionalObjectDictionaryOfArrays(left, map: right)
 	}
 }
-
-/*
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable>
-public func <- <T: BaseMappable>(left: inout Dictionary<String, [T]>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectDictionaryOfArrays(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
 
 // MARK:- Array of Mappable objects - Array<T: BaseMappable>
 
@@ -270,19 +218,6 @@ public func >>> <T: BaseMappable>(left: Array<T>?, right: Map) {
 	}
 }
 
-/*
-/// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: BaseMappable>(left: inout Array<T>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalObjectArray(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
-
 // MARK:- Array of Array of Mappable objects - Array<Array<T: BaseMappable>>
 
 /// Array of Array Mappable objects
@@ -319,19 +254,6 @@ public func >>> <T: BaseMappable>(left: Array<Array<T>>?, right: Map) {
 		ToJSON.optionalTwoDimensionalObjectArray(left, map: right)
 	}
 }
-
-/*
-/// Implicitly unwrapped Optional array of Mappable objects
-public func <- <T: BaseMappable>(left: inout Array<Array<T>>!, right: Map) {
-	switch right.mappingType {
-	case .fromJSON where right.isKeyPresent:
-		FromJSON.optionalTwoDimensionalObjectArray(&left, map: right)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
 
 // MARK:- Set of Mappable objects - Set<T: BaseMappable>
 

--- a/Pods/ObjectMapper/Sources/TransformOperators.swift
+++ b/Pods/ObjectMapper/Sources/TransformOperators.swift
@@ -52,21 +52,6 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 		ToJSON.optionalBasicType(value, map: map)
 	}
 }
-
-/*
-/// Implicitly unwrapped optional object of basic type with Transform
-public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let value = transform.transformFromJSON(map.currentValue)
-		FromJSON.optionalBasicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-*/
  
 /// Array of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [Transform.Object], right: (Map, Transform)) {
@@ -111,21 +96,6 @@ public func >>> <Transform: TransformType>(left: [Transform.Object]?, right: (Ma
 	}
 }
 
-/*
-/// Implicitly unwrapped optional array of Basic type with Transform
-public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let values = fromJSONArrayWithTransform(map.currentValue, transform: transform)
-		FromJSON.optionalBasicType(&left, object: values)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
-
 /// Dictionary of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
@@ -168,21 +138,6 @@ public func >>> <Transform: TransformType>(left: [String: Transform.Object]?, ri
 		ToJSON.optionalBasicType(values, map: map)
 	}
 }
-
-/*
-/// Implicitly unwrapped optional dictionary of Basic type with Transform
-public func <- <Transform: TransformType>(left: inout [String: Transform.Object]!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let values = fromJSONDictionaryWithTransform(map.currentValue, transform: transform)
-		FromJSON.optionalBasicType(&left, object: values)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
 
 // MARK:- Transforms of Mappable Objects - <T: BaseMappable>
 
@@ -229,22 +184,6 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 	}
 }
 
-/*
-/// Implicitly unwrapped optional Mappable objects that have transforms
-public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let value: Transform.Object? = transform.transformFromJSON(map.currentValue)
-		FromJSON.optionalBasicType(&left, object: value)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
-
-
 // MARK:- Dictionary of Mappable objects with a transform - Dictionary<String, T: BaseMappable>
 
 /// Dictionary of Mappable objects <String, T: Mappable> with a transform
@@ -286,19 +225,6 @@ public func >>> <Transform: TransformType>(left: Dictionary<String, Transform.Ob
 		ToJSON.optionalBasicType(value, map: map)
 	}
 }
-
-/*
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType>(left: inout Dictionary<String, Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	if map.mappingType == .fromJSON && map.isKeyPresent, let dictionary = map.currentValue as? [String : Any]{
-		let transformedDictionary = fromJSONDictionaryWithTransform(dictionary as Any?, transform: transform) ?? left
-		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .toJSON {
-		left >>> right
-	}
-}
- */
 
 /// Dictionary of Mappable objects <String, T: Mappable> with a transform
 public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transform.Object]>, right: (Map, Transform)) where Transform.Object: BaseMappable {
@@ -371,29 +297,6 @@ public func >>> <Transform: TransformType>(left: Dictionary<String, [Transform.O
 	}
 }
 
-/*
-/// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
-public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	
-	if let dictionary = map.currentValue as? [String : [Any]], map.mappingType == .fromJSON && map.isKeyPresent {
-		let transformedDictionary = dictionary.map { (arg: (key: String, values: [Any])) -> (String, [Transform.Object]) in
-			let (key, values) = arg
-			if let jsonArray = fromJSONArrayWithTransform(values, transform: transform) {
-				return (key, jsonArray)
-			}
-			if let leftValue = left?[key] {
-				return (key, leftValue)
-			}
-			return (key, [])
-		}
-		FromJSON.optionalBasicType(&left, object: transformedDictionary)
-	} else if map.mappingType == .toJSON {
-		left >>> right
-	}
-}
- */
-
 // MARK:- Array of Mappable objects with transforms - Array<T: BaseMappable>
 
 /// Array of Mappable objects
@@ -439,21 +342,6 @@ public func >>> <Transform: TransformType>(left: Array<Transform.Object>?, right
 		ToJSON.optionalBasicType(transformedValues, map: map)
 	}
 }
-
-/*
-/// Implicitly unwrapped Optional array of Mappable objects
-public func <- <Transform: TransformType>(left: inout Array<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform)
-		FromJSON.optionalBasicType(&left, object: transformedValues)
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
- */
 
 // MARK:- Array of Array of objects - Array<Array<T>>> with transforms
 
@@ -511,25 +399,6 @@ public func >>> <Transform: TransformType>(left: [[Transform.Object]]?, right: (
 	}
 }
 
-/*
-/// Implicitly unwrapped Optional array of array of objects with transform
-public func <- <Transform: TransformType>(left: inout [[Transform.Object]]!, right: (Map, Transform)) {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .toJSON:
-		left >>> right
-	case .fromJSON where map.isKeyPresent:
-		guard let original2DArray = map.currentValue as? [[Any]] else { break }
-		let transformed2DArray = original2DArray.flatMap { values in
-			fromJSONArrayWithTransform(values as Any?, transform: transform)
-		}
-		FromJSON.optionalBasicType(&left, object: transformed2DArray)
-	default:
-		break
-	}
-}
- */
-
 // MARK:- Set of Mappable objects with a transform - Set<T: BaseMappable>
 
 /// Set of Mappable objects with transform
@@ -578,22 +447,6 @@ public func >>> <Transform: TransformType>(left: Set<Transform.Object>?, right: 
 		}
 	}
 }
-
-/*
-/// Implicitly unwrapped Optional set of Mappable objects with transform
-public func <- <Transform: TransformType>(left: inout Set<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
-	let (map, transform) = right
-	switch map.mappingType {
-	case .fromJSON where map.isKeyPresent:
-		if let transformedValues = fromJSONArrayWithTransform(map.currentValue, transform: transform) {
-			FromJSON.basicType(&left, object: Set(transformedValues))
-		}
-	case .toJSON:
-		left >>> right
-	default: ()
-	}
-}
-*/
 
 private func fromJSONArrayWithTransform<Transform: TransformType>(_ input: Any?, transform: Transform) -> [Transform.Object]? {
 	if let values = input as? [Any] {

--- a/Pods/ObjectMapper/Sources/TransformOperators.swift
+++ b/Pods/ObjectMapper/Sources/TransformOperators.swift
@@ -53,7 +53,7 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 	}
 }
 
-
+/*
 /// Implicitly unwrapped optional object of basic type with Transform
 public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) {
 	let (map, transform) = right
@@ -66,7 +66,8 @@ public func <- <Transform: TransformType>(left: inout Transform.Object!, right: 
 	default: ()
 	}
 }
-
+*/
+ 
 /// Array of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [Transform.Object], right: (Map, Transform)) {
 	let (map, transform) = right
@@ -110,7 +111,7 @@ public func >>> <Transform: TransformType>(left: [Transform.Object]?, right: (Ma
 	}
 }
 
-
+/*
 /// Implicitly unwrapped optional array of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right: (Map, Transform)) {
 	let (map, transform) = right
@@ -123,6 +124,7 @@ public func <- <Transform: TransformType>(left: inout [Transform.Object]!, right
 	default: ()
 	}
 }
+ */
 
 /// Dictionary of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object], right: (Map, Transform)) {
@@ -167,7 +169,7 @@ public func >>> <Transform: TransformType>(left: [String: Transform.Object]?, ri
 	}
 }
 
-
+/*
 /// Implicitly unwrapped optional dictionary of Basic type with Transform
 public func <- <Transform: TransformType>(left: inout [String: Transform.Object]!, right: (Map, Transform)) {
 	let (map, transform) = right
@@ -180,6 +182,7 @@ public func <- <Transform: TransformType>(left: inout [String: Transform.Object]
 	default: ()
 	}
 }
+ */
 
 // MARK:- Transforms of Mappable Objects - <T: BaseMappable>
 
@@ -226,7 +229,7 @@ public func >>> <Transform: TransformType>(left: Transform.Object?, right: (Map,
 	}
 }
 
-
+/*
 /// Implicitly unwrapped optional Mappable objects that have transforms
 public func <- <Transform: TransformType>(left: inout Transform.Object!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
@@ -239,6 +242,7 @@ public func <- <Transform: TransformType>(left: inout Transform.Object!, right: 
 	default: ()
 	}
 }
+ */
 
 
 // MARK:- Dictionary of Mappable objects with a transform - Dictionary<String, T: BaseMappable>
@@ -283,7 +287,7 @@ public func >>> <Transform: TransformType>(left: Dictionary<String, Transform.Ob
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
 public func <- <Transform: TransformType>(left: inout Dictionary<String, Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
@@ -294,6 +298,7 @@ public func <- <Transform: TransformType>(left: inout Dictionary<String, Transfo
 		left >>> right
 	}
 }
+ */
 
 /// Dictionary of Mappable objects <String, T: Mappable> with a transform
 public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transform.Object]>, right: (Map, Transform)) where Transform.Object: BaseMappable {
@@ -366,7 +371,7 @@ public func >>> <Transform: TransformType>(left: Dictionary<String, [Transform.O
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional Dictionary of Mappable object <String, T: Mappable> with a transform
 public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transform.Object]>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
@@ -387,6 +392,7 @@ public func <- <Transform: TransformType>(left: inout Dictionary<String, [Transf
 		left >>> right
 	}
 }
+ */
 
 // MARK:- Array of Mappable objects with transforms - Array<T: BaseMappable>
 
@@ -434,7 +440,7 @@ public func >>> <Transform: TransformType>(left: Array<Transform.Object>?, right
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional array of Mappable objects
 public func <- <Transform: TransformType>(left: inout Array<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
@@ -447,6 +453,7 @@ public func <- <Transform: TransformType>(left: inout Array<Transform.Object>!, 
 	default: ()
 	}
 }
+ */
 
 // MARK:- Array of Array of objects - Array<Array<T>>> with transforms
 
@@ -504,7 +511,7 @@ public func >>> <Transform: TransformType>(left: [[Transform.Object]]?, right: (
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional array of array of objects with transform
 public func <- <Transform: TransformType>(left: inout [[Transform.Object]]!, right: (Map, Transform)) {
 	let (map, transform) = right
@@ -521,6 +528,7 @@ public func <- <Transform: TransformType>(left: inout [[Transform.Object]]!, rig
 		break
 	}
 }
+ */
 
 // MARK:- Set of Mappable objects with a transform - Set<T: BaseMappable>
 
@@ -571,7 +579,7 @@ public func >>> <Transform: TransformType>(left: Set<Transform.Object>?, right: 
 	}
 }
 
-
+/*
 /// Implicitly unwrapped Optional set of Mappable objects with transform
 public func <- <Transform: TransformType>(left: inout Set<Transform.Object>!, right: (Map, Transform)) where Transform.Object: BaseMappable {
 	let (map, transform) = right
@@ -585,7 +593,7 @@ public func <- <Transform: TransformType>(left: inout Set<Transform.Object>!, ri
 	default: ()
 	}
 }
-
+*/
 
 private func fromJSONArrayWithTransform<Transform: TransformType>(_ input: Any?, transform: Transform) -> [Transform.Object]? {
 	if let values = input as? [Any] {


### PR DESCRIPTION
ObjectMapper pod had to be brought up to new spec after iOS 12 updates.  There is no updated version on the ObjectMapper project page https://github.com/Hearst-DD/ObjectMapper so we updated it ourselves for now.