### PR TITLE
Fixed issues #26, #27, #28, #29

### DIFF
--- a/EAO.xcodeproj/project.pbxproj
+++ b/EAO.xcodeproj/project.pbxproj
@@ -247,6 +247,8 @@
 		95CF462D7588D8B3207A134B /* Pods_EAOUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7264A000F4E6ED7FD7102F7 /* Pods_EAOUITests.framework */; };
 		9688D51C1E69DA4300C49CD7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9688D51B1E69DA4300C49CD7 /* AppDelegate.swift */; };
 		CFA9994DB092C61D27ED1854 /* Pods_Field_Insp_TEST.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A66651935004DE845E747AF /* Pods_Field_Insp_TEST.framework */; };
+		D52C30C321FE468E00EDAC38 /* PFTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52C30C221FE468E00EDAC38 /* PFTeam.swift */; };
+		D52C30C521FE489100EDAC38 /* PFTeam.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52C30C221FE468E00EDAC38 /* PFTeam.swift */; };
 		D5391DBB21E7125F00FC4055 /* Podfile in Resources */ = {isa = PBXBuildFile; fileRef = D5391DBA21E7125F00FC4055 /* Podfile */; };
 		D53B6DDC21CB61D000A0F546 /* RealmLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53B6DDB21CB61CF00A0F546 /* RealmLocation.swift */; };
 		D53B6DDF21CB622E00A0F546 /* InspectionError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D53B6DDE21CB622E00A0F546 /* InspectionError.swift */; };
@@ -495,6 +497,7 @@
 		B7264A000F4E6ED7FD7102F7 /* Pods_EAOUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_EAOUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CCCC9EF18BF5162D2E6C2AA3 /* Pods-EAO.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EAO.release.xcconfig"; path = "Pods/Target Support Files/Pods-EAO/Pods-EAO.release.xcconfig"; sourceTree = "<group>"; };
 		CF2A00FA0155E41D4235A3F6 /* Pods-EAOTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-EAOTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-EAOTests/Pods-EAOTests.release.xcconfig"; sourceTree = "<group>"; };
+		D52C30C221FE468E00EDAC38 /* PFTeam.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PFTeam.swift; sourceTree = "<group>"; };
 		D5391DB721E7123800FC4055 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = EAO/README.md; sourceTree = "<group>"; };
 		D5391DB921E7124700FC4055 /* CHANGELOG.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CHANGELOG.md; sourceTree = "<group>"; };
 		D5391DBA21E7125F00FC4055 /* Podfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Podfile; sourceTree = SOURCE_ROOT; };
@@ -661,6 +664,7 @@
 				D5F7DE3C21E1E60E00C0A859 /* PFPhotoThumb.swift */,
 				D5F7DE3621E1E56D00C0A859 /* PFAudio.swift */,
 				D5F7DE3321E1E51F00C0A859 /* PFVideo.swift */,
+				D52C30C221FE468E00EDAC38 /* PFTeam.swift */,
 				D53B6DDB21CB61CF00A0F546 /* RealmLocation.swift */,
 				29A4FFA5207358DD0036549D /* User.swift */,
 				291746732073E77F005F70B4 /* Team.swift */,
@@ -1596,6 +1600,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D52C30C521FE489100EDAC38 /* PFTeam.swift in Sources */,
 				2936BEB120BF64A500775F5E /* UIApplication.swift in Sources */,
 				2936BEB220BF64A500775F5E /* NewDescriptionTableViewCell.swift in Sources */,
 				2936BEB420BF64A500775F5E /* GalleryMode.swift in Sources */,
@@ -1731,6 +1736,7 @@
 				2917467C2073EC42005F70B4 /* TeamSearchTableViewCell.swift in Sources */,
 				295304F02017FF59001E5C7F /* MiButtonStyle.swift in Sources */,
 				29A029EF2029FECC0085DCE8 /* Recorder.swift in Sources */,
+				D52C30C321FE468E00EDAC38 /* PFTeam.swift in Sources */,
 				29424D441FFC146200562508 /* HexColor.swift in Sources */,
 				119A0B841EE785300077D9B5 /* Reachability.swift in Sources */,
 				5675DA9521935C00008409AB /* Theme.swift in Sources */,

--- a/EAO.xcodeproj/project.pbxproj
+++ b/EAO.xcodeproj/project.pbxproj
@@ -1209,6 +1209,7 @@
 						TestTargetID = 9688D5171E69DA4300C49CD7;
 					};
 					2936BEAE20BF64A500775F5E = {
+						DevelopmentTeam = SKJCUF8GFH;
 						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
@@ -1874,7 +1875,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = SKJCUF8GFH;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = "Info-Test.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -1897,7 +1898,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = SKJCUF8GFH;
 				INFOPLIST_FILE = "Info-Test.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "ca.bc.gov.pathfinder.mobile.FieldInspection-Test";

--- a/EAO/Audio.swift
+++ b/EAO/Audio.swift
@@ -39,9 +39,9 @@ extension Audio: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFAudio()
-        object.id = self.id
-        object.observationId = self.observationId
-        object.inspectionId = self.inspectionId
+        // Do not set the `id` property.
+//        object.observationId = self.observationId
+//        object.inspectionId = self.inspectionId
         object.notes = self.notes
         if let urlString = self.url {
             object.url = URL(string: urlString)

--- a/EAO/Audio.swift
+++ b/EAO/Audio.swift
@@ -12,7 +12,6 @@ final class Audio: Object {
     
     @objc dynamic var id: String = "\(UUID().uuidString).mp4a"
     @objc dynamic var observationId: String?
-    @objc dynamic var inspectionId: String?
     @objc dynamic var index: Int = 0
     @objc dynamic var notes: String?
     @objc dynamic var title: String?

--- a/EAO/Audio.swift
+++ b/EAO/Audio.swift
@@ -24,12 +24,12 @@ final class Audio: Object {
     }
 
     @objc func get() -> Data? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return try? Data(contentsOf: url)
     }
     
     @objc func getURL() -> URL? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return url
     }
 }

--- a/EAO/Audio.swift
+++ b/EAO/Audio.swift
@@ -39,9 +39,7 @@ extension Audio: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFAudio()
-        // Do not set the `id` property.
-//        object.observationId = self.observationId
-//        object.inspectionId = self.inspectionId
+        // Do not set the properties: `id`, `observationId`, `inspectionId`.
         object.notes = self.notes
         if let urlString = self.url {
             object.url = URL(string: urlString)

--- a/EAO/DataServices+Audio.swift
+++ b/EAO/DataServices+Audio.swift
@@ -17,7 +17,6 @@ extension DataServices {
         let audio = Audio()
         audio.observationId = observationID
         audio.index = index
-        audio.inspectionId = inspectionID
         audio.notes = notes
         audio.title = title
         let data = NSData(contentsOf: audioURL)

--- a/EAO/DataServices+Photos.swift
+++ b/EAO/DataServices+Photos.swift
@@ -12,22 +12,17 @@ import AlamofireObjectMapper
 
 extension DataServices {
     
-    internal class func savePhoto(image: UIImage, index: Int, location: CLLocation?, observationID: String, description: String?, completion: @escaping (_ created: Bool) -> Void) {
+    /**
+     Create Photo and PhotoThumb, don't save them to Realm yet,
+     */
+    class func preparePhoto(image: UIImage, index: Int, location: CLLocation?, observationID: String, description: String?) -> (PhotoThumb, Photo)? {
         
-        DataServices.saveThumbnail(image: image, index: index, originalType: "photo", observationID: observationID, description: description) { (result) in
-            guard result else {
-                return completion (false)
-            }
-            
-            DataServices.saveFull(image: image, index: index, location: location, observationID: observationID, description: description) { (success) in
-                if !success { return completion (false)}
-                
-                return completion(true)
-            }
+        guard let dataPhoto: Data = UIImage.resizeImage(image: image).jpegData(compressionQuality: 0) else {
+            return nil
         }
-    }
-    
-    internal class func saveFull(image: UIImage, index: Int, location: CLLocation?, observationID: String, description: String?, completion: @escaping (_ created: Bool) -> Void) {
+        guard let dataThumb: Data = UIImage.resizeImage(image: image).jpegData(compressionQuality: 0) else {
+            return nil
+        }
         
         let photo = Photo()
         photo.caption = description
@@ -35,8 +30,43 @@ extension DataServices {
         photo.index = index
         photo.coordinate = RealmLocation(location: location)
         
-        let data = image.toData(quality: .uncompressed)
-        print("full size of \(index) is \(data.count)")
+        let photoThumb = PhotoThumb()
+        photoThumb.observationId = observationID
+        photoThumb.originalType = "photo"
+        photoThumb.index = index
+
+        do {
+            try dataPhoto.write(to: FileManager.directory.appendingPathComponent(photo.id, isDirectory: false))
+            try dataThumb.write(to: FileManager.directory.appendingPathComponent(photoThumb.id, isDirectory: false))
+        } catch let error {
+            print("\(#function) \(error)")
+            return nil
+        }
+        
+        return (photoThumb, photo)
+    }
+    
+    class func savePhoto(image: UIImage, index: Int, location: CLLocation?, observationID: String, description: String?) -> Bool {
+        
+        if let _ = DataServices.saveThumbnail(image: image, index: index, originalType: "photo", observationID: observationID, description: description),
+            let _ = DataServices.saveFull(image: image, index: index, location: location, observationID: observationID, description: description) {
+            return true
+        }
+        return false
+    }
+    
+    internal class func saveFull(image: UIImage, index: Int, location: CLLocation?, observationID: String, description: String?) -> String? {
+        
+        guard let data: Data = UIImage.resizeImage(image: image).jpegData(compressionQuality: 0) else {
+            return nil
+        }
+        print("Image full size of \(index) is \(data.count)")
+
+        let photo = Photo()
+        photo.caption = description
+        photo.observationId = observationID
+        photo.index = index
+        photo.coordinate = RealmLocation(location: location)
         
         do {
             let realm = try Realm()
@@ -44,17 +74,17 @@ extension DataServices {
             try realm.write {
                 realm.add(photo, update: true)
             }
-            return completion(true)
+            return photo.id
         } catch let error {
             print("Realm or Data save exception \(error.localizedDescription)")
-            return completion(false)
+            return nil
         }
     }
     
-    internal class func saveThumbnail(image: UIImage, index: Int, originalType: String, observationID: String, description: String?, completion: @escaping (_ created: Bool) -> Void) {
+    internal class func saveThumbnail(image: UIImage, index: Int, originalType: String, observationID: String, description: String?) -> String? {
         
         guard let data: Data = UIImage.resizeImage(image: image).jpegData(compressionQuality: 0) else {
-            return completion(false)
+            return nil
         }
         print("thumb size of \(index) is \(data.count)")
         
@@ -70,11 +100,10 @@ extension DataServices {
             try realm.write {
                 realm.add(photo, update: true)
             }
-            
-            return completion(true)
+            return photo.id
         } catch let error {
             print("Realm or Data save exception \(error.localizedDescription)")
-            return completion(false)
+            return nil
         }
     }
     
@@ -90,15 +119,14 @@ extension DataServices {
         }
     }
     
-    internal class func getPhotoFor(observationID: String, at index: Int, completion: @escaping (_ success: Bool, _ photos: Photo? ) -> Void) {
+    internal class func getPhoto(for observationID: String, at index: Int) -> Photo? {
 
         let photos = DataServices.getPhotos(for: observationID)
         if photos.count > 0 {
-            let thePhoto = photos.filter({ $0.index == index }).first
-            return completion(false, thePhoto)
-        } else {
-            return completion(false, nil)
+            let photo = photos.filter({ $0.index == index }).first
+            return photo
         }
+        return nil
     }
     
     internal class func getThumbnailsFor(observationID: String, completion: @escaping (_ success: Bool, _ photos: [PhotoThumb]? ) -> Void) {

--- a/EAO/DataServices+Video.swift
+++ b/EAO/DataServices+Video.swift
@@ -13,7 +13,7 @@ import AVFoundation
 
 extension DataServices {
 
-    internal class func getVideosFor(observationID: String, completion: @escaping (_ success: Bool, _ videos: [Video]? ) -> Void) {
+    internal class func getVideos(for observationID: String) -> [Video]? {
         
         do {
             let realm = try Realm()
@@ -21,50 +21,41 @@ extension DataServices {
             let resultsArray = Array(results)
             
             print("\(#function): count = \(results.count)");
-            return completion(true, resultsArray)
+            return resultsArray
         } catch let error {
             print("\(#function): \(error.localizedDescription)");
-            return completion(false, nil)
         }
+        return nil
     }
     
-    internal class func getVideoFor(observationID: String, at index: Int, completion: @escaping (_ success: Bool, _ video: Video? ) -> Void) {
+    internal class func getVideo(for observationID: String, at index: Int) -> Video? {
         
-        DataServices.getVideosFor(observationID: observationID) { (success, results) in
-            if success == true, (results?.count ?? 0) > 0 {
-                let theOne = results?.filter({ $0.index == index }).first
-                return completion(false, theOne)
-            } else {
-                return completion(false, nil)
-            }
-        }
+        let videos = DataServices.getVideos(for: observationID)
+        let video = videos?.filter({ $0.index == index }).first
+        return video
     }
 
     internal class func saveVideo(avAsset: AVAsset, thumbnail: UIImage,index: Int, observationID: String, description: String?, completion: @escaping (_ created: Bool) -> Void) {
         
-        DataServices.saveThumbnail(image: thumbnail, index: index, originalType: "video", observationID: observationID, description: description) { (result) in
-            
-            guard result else {
-                return completion (false)
-            }
+        if let _ = DataServices.saveThumbnail(image: thumbnail, index: index, originalType: "video", observationID: observationID, description: description) {
             
             // then save video
             let video = Video()
             video.observationId = observationID
             video.index = index
             video.notes = description
-            let exportURL: URL = FileManager.directory.appendingPathComponent(video.id, isDirectory: true)
+            let exportURL: URL = FileManager.directory.appendingPathComponent(video.id, isDirectory: false)
             let exporter = AVAssetExportSession(asset: avAsset, presetName: AVAssetExportPresetHighestQuality)
             exporter?.outputFileType = AVFileType.mov
             exporter?.outputURL = exportURL
             
             exporter?.exportAsynchronously(completionHandler: {
-                DataServices.savePFVideo(video: video, completion: completion)
+                DataServices.saveVideo(video: video, completion: completion)
             })
         }
     }
     
-    internal class func savePFVideo(video: Video, completion: @escaping (_ created: Bool) -> Void) {
+    internal class func saveVideo(video: Video, completion: @escaping (_ created: Bool) -> Void) {
         
         do {
             let realm = try Realm()
@@ -78,17 +69,4 @@ extension DataServices {
         }
     }
     
-    internal class func getVideoAt(observationID: String, at index: Int, completion: @escaping (_ success: Bool, _ video: Video? ) -> Void) {
-        getVideosFor(observationID: observationID) { (found, videos) in
-            
-            if found {
-                if (videos?.count)! >= index {
-                    return completion(true,  videos?[index])
-                } else {
-                    return completion(false, nil)
-                }
-            }
-            return completion(false, nil)
-        }
-    }
 }

--- a/EAO/Models/Inspection.swift
+++ b/EAO/Models/Inspection.swift
@@ -73,7 +73,8 @@ extension Inspection: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFInspection()
-        // Do not set the properties: `id`, `teamID`.
+        // save local inspection ID
+        object["localId"] = self.id
         object.userId = self.userId
         object.project = self.project
         object.title = self.title
@@ -82,7 +83,6 @@ extension Inspection: ParseFactory {
         object.number = self.number
         object.start = self.start
         object.end = self.end
-        object.team = PFTeam(withoutDataWithObjectId: "En8opj65uJ")
 
         return object
     }

--- a/EAO/Models/Inspection.swift
+++ b/EAO/Models/Inspection.swift
@@ -81,6 +81,7 @@ extension Inspection: ParseFactory {
         object.number = self.number
         object.start = self.start
         object.end = self.end
+        object.team = PFTeam(withoutDataWithObjectId: "En8opj65uJ")
 
         return object
     }

--- a/EAO/Models/Inspection.swift
+++ b/EAO/Models/Inspection.swift
@@ -71,19 +71,18 @@ extension Inspection: ParseFactory {
     
     func createParseObject() -> PFObject {
         
-        let pfInspection = PFInspection()
-        pfInspection.id = self.id
-        pfInspection.userId = self.userId
-        pfInspection.project = self.project
-        pfInspection.title = self.title
-        pfInspection.subtitle = self.subtitle
-        pfInspection.subtitle = self.subtitle
-        pfInspection.subtext = self.subtext
-        pfInspection.number = self.number
-        pfInspection.start = self.start
-        pfInspection.end = self.end
-        pfInspection.teamID = self.teamID
+        let object = PFInspection()
+        // Do not set the `id` property.
+        object.userId = self.userId
+        object.project = self.project
+        object.title = self.title
+        object.subtitle = self.subtitle
+        object.subtext = self.subtext
+        object.number = self.number
+        object.start = self.start
+        object.end = self.end
+        object.teamID = self.teamID
 
-        return pfInspection
+        return object
     }
 }

--- a/EAO/Models/Inspection.swift
+++ b/EAO/Models/Inspection.swift
@@ -72,7 +72,7 @@ extension Inspection: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFInspection()
-        // Do not set the `id` property.
+        // Do not set the properties: `id`, `teamID`.
         object.userId = self.userId
         object.project = self.project
         object.title = self.title
@@ -81,7 +81,6 @@ extension Inspection: ParseFactory {
         object.number = self.number
         object.start = self.start
         object.end = self.end
-        object.teamID = self.teamID
 
         return object
     }

--- a/EAO/Models/Inspection.swift
+++ b/EAO/Models/Inspection.swift
@@ -41,6 +41,7 @@ class Inspection: Object {
     // MARK: Properties
     @objc dynamic var id: String = UUID().uuidString
     @objc dynamic var userId: String?
+    @objc dynamic var objectId: String?
     @objc dynamic var isSubmitted: Bool = false
     @objc dynamic var project: String?
     @objc dynamic var title: String?

--- a/EAO/Models/Observation.swift
+++ b/EAO/Models/Observation.swift
@@ -43,7 +43,7 @@ extension Observation: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFObservation()
-        object.id = self.id
+        // Do not set the `id` property.
         object.inspectionId = self.inspectionId
         object.title = self.title
         object.requirement = self.requirement

--- a/EAO/Models/Observation.swift
+++ b/EAO/Models/Observation.swift
@@ -43,8 +43,7 @@ extension Observation: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFObservation()
-        // Do not set the `id` property.
-        object.inspectionId = self.inspectionId
+        // Do not set the properties: `id`, `observationId`, `inspectionId`.
         object.title = self.title
         object.requirement = self.requirement
         object.coordinate = self.coordinate?.createParseObject()

--- a/EAO/Models/PFPhoto.swift
+++ b/EAO/Models/PFPhoto.swift
@@ -18,7 +18,8 @@ final class PFPhoto: PFObject, PFSubclassing {
     @NSManaged var timestamp: Date?
     @NSManaged var coordinate: PFGeoPoint?
     @NSManaged var index: NSNumber?
-    
+    @NSManaged var observation: PFObservation?
+
     static func parseClassName() -> String {
         return "Photo"
     }

--- a/EAO/Models/PFPhoto.swift
+++ b/EAO/Models/PFPhoto.swift
@@ -13,7 +13,7 @@ final class PFPhoto: PFObject, PFSubclassing {
     
     @NSManaged var id: String?
     @NSManaged var observationId: String?
-    @NSManaged var file: PFFileObject?
+    @NSManaged var photo: PFFileObject?
     @NSManaged var caption: String?
     @NSManaged var timestamp: Date?
     @NSManaged var coordinate: PFGeoPoint?

--- a/EAO/Models/Photo.swift
+++ b/EAO/Models/Photo.swift
@@ -39,8 +39,8 @@ extension Photo: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFPhoto()
-        object.id = self.id
-        object.observationId = self.observationId
+        // Do not set the `id` property.
+//        object.observationId = self.observationId
         object.caption = self.caption
         object.timestamp = self.timestamp
         object.coordinate = self.coordinate?.createParseObject()

--- a/EAO/Models/Photo.swift
+++ b/EAO/Models/Photo.swift
@@ -39,15 +39,14 @@ extension Photo: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFPhoto()
-        // Do not set the `id` property.
-//        object.observationId = self.observationId
+        // Do not set the properties: `id`, `observationId`.
         object.caption = self.caption
         object.timestamp = self.timestamp
         object.coordinate = self.coordinate?.createParseObject()
         object.index = NSNumber(value: self.index)
         
         if let fileData = self.get() {
-            object.file = PFFileObject(data: fileData)
+            object.photo = PFFileObject(data: fileData)
         }
 
         return object

--- a/EAO/Models/Photo.swift
+++ b/EAO/Models/Photo.swift
@@ -12,7 +12,7 @@ class Photo: Object {
     
     //Use this variable for image caching
     var image: UIImage? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return UIImage(contentsOfFile: url.path)
     }
     
@@ -29,7 +29,7 @@ class Photo: Object {
     }
 
     @objc func get() -> Data? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return try? Data(contentsOf: url)
     }
 }

--- a/EAO/Models/PhotoThumb.swift
+++ b/EAO/Models/PhotoThumb.swift
@@ -12,7 +12,7 @@ class PhotoThumb: Object {
     
     //Use this variable for image caching
     var image: UIImage? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return UIImage(contentsOfFile: url.path)
     }
     
@@ -28,7 +28,7 @@ class PhotoThumb: Object {
     }
 
     @objc func get() -> Data? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return try? Data(contentsOf: url)
     }
 }

--- a/EAO/Models/PhotoThumb.swift
+++ b/EAO/Models/PhotoThumb.swift
@@ -40,6 +40,7 @@ extension PhotoThumb: ParseFactory {
         let object = PFPhotoThumb()
         // Do not set the properties: `id`, `observationId`, `inspectionId`.
         object.index = NSNumber(value: self.index)
+        object.originalType = originalType
         
         if let fileData = self.get() {
             object.file = PFFileObject(data: fileData)

--- a/EAO/Models/PhotoThumb.swift
+++ b/EAO/Models/PhotoThumb.swift
@@ -38,8 +38,8 @@ extension PhotoThumb: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFPhotoThumb()
-        object.id = self.id
-        object.observationId = self.observationId
+        // Do not set the `id` property.
+//        object.observationId = self.observationId
         object.index = NSNumber(value: self.index)
         
         if let fileData = self.get() {

--- a/EAO/Models/PhotoThumb.swift
+++ b/EAO/Models/PhotoThumb.swift
@@ -38,8 +38,7 @@ extension PhotoThumb: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFPhotoThumb()
-        // Do not set the `id` property.
-//        object.observationId = self.observationId
+        // Do not set the properties: `id`, `observationId`, `inspectionId`.
         object.index = NSNumber(value: self.index)
         
         if let fileData = self.get() {

--- a/EAO/PFAudio.swift
+++ b/EAO/PFAudio.swift
@@ -19,6 +19,7 @@ final class PFAudio: PFObject, PFSubclassing {
     @NSManaged var title: String?
     @NSManaged var url: URL?
     @NSManaged var file: PFFileObject?
+    @NSManaged var observation: PFObservation?
 
     static func parseClassName() -> String {
         return "Audio"

--- a/EAO/PFInspection.swift
+++ b/EAO/PFInspection.swift
@@ -98,7 +98,7 @@ extension PFInspection {
         query.findObjectsInBackground(block: { (inspections, error) in
             
             for inspection in inspections as? [PFInspection] ?? [] {
-                guard let _ = inspection.id else {
+                guard let _ = inspection.objectId else {
                     continue
                 }
                 let _ = DataServices.add(inspection: inspection)

--- a/EAO/PFInspection.swift
+++ b/EAO/PFInspection.swift
@@ -36,29 +36,11 @@ enum PFInspectionError: Error {
 final class PFInspection: PFObject, PFSubclassing {
     internal var progress: Float = 0
     internal var isBeingUploaded = false
-    internal var isStoredLocally: Bool {
-        get {
-            guard let id = self.id, let realm = try? Realm(), let inspection = realm.objects(InspectionMeta.self).filter("localId == %@", id).first else {
-                return false
-            }
-            
-            return inspection.isStoredLocally
-        }
-        set (value) {
-            guard let id = self.id, let realm = try? Realm(), let inspection = realm.objects(InspectionMeta.self).filter("localId == %@", id).first else {
-                return
-            }
-            
-            try? realm.write {
-                inspection.isStoredLocally = value
-            }
-        }
-    }
+
     internal var failed = [PFObject]()
     
     // MARK: -
-    
-    @NSManaged var id: String?
+    @NSManaged var localId: String?
     @NSManaged var userId: String?
     @NSManaged var isSubmitted: NSNumber?
     @NSManaged var isActive: NSNumber?

--- a/EAO/PFInspection.swift
+++ b/EAO/PFInspection.swift
@@ -71,7 +71,8 @@ final class PFInspection: PFObject, PFSubclassing {
     @NSManaged var end: Date?
     @NSManaged var teamID: String?
     @NSManaged var observation: [PFObservation]
-    
+    @NSManaged var team: PFTeam?
+
     static func parseClassName() -> String {
         return "Inspection"
     }

--- a/EAO/PFInspection.swift
+++ b/EAO/PFInspection.swift
@@ -61,6 +61,7 @@ final class PFInspection: PFObject, PFSubclassing {
     @NSManaged var id: String?
     @NSManaged var userId: String?
     @NSManaged var isSubmitted: NSNumber?
+    @NSManaged var isActive: NSNumber?
     @NSManaged var project: String?
     @NSManaged var title: String?
     @NSManaged var subtitle: String?

--- a/EAO/PFObservation.swift
+++ b/EAO/PFObservation.swift
@@ -16,7 +16,8 @@ final class PFObservation: PFObject, PFSubclassing {
     @NSManaged var coordinate: PFGeoPoint?
     @NSManaged var pinnedAt: Date?
     @NSManaged var observationDescription: String?
-    
+    @NSManaged var inspection: PFInspection?
+
     static func parseClassName() -> String {
         return "Observation"
     }

--- a/EAO/PFPhotoThumb.swift
+++ b/EAO/PFPhotoThumb.swift
@@ -13,9 +13,10 @@ final class PFPhotoThumb: PFObject, PFSubclassing {
     @NSManaged var id: String?
     @NSManaged var observationId: String?
     @NSManaged var index: NSNumber?
-    // original asset type: Video? Photo?
+    // original asset type: "Video" "Photo"
     @NSManaged var originalType: String?
     @NSManaged var file: PFFileObject?
+    @NSManaged var observation: PFObservation?
 
     static func parseClassName() -> String {
         return "PhotoThumb"

--- a/EAO/PFTeam.swift
+++ b/EAO/PFTeam.swift
@@ -1,0 +1,24 @@
+//
+//  PFTeam.swift
+//  Field Insp
+//
+//  Created by Evgeny Yagrushkin on 2019-01-27.
+//  Copyright © 2019 Province of British Columbia. All rights reserved.
+//
+
+import Parse
+
+final class PFTeam: PFObject, PFSubclassing {
+
+    @NSManaged var id: String?
+    @NSManaged var color: String?
+    @NSManaged var badge: PFFileObject?
+    @NSManaged var users: [PFObject]
+    @NSManaged var name: String?
+    @NSManaged var isActive: NSNumber?
+    @NSManaged var teamAdmin: PFObject?
+    
+    static func parseClassName() -> String {
+        return "Team"
+    }
+}

--- a/EAO/PFVideo.swift
+++ b/EAO/PFVideo.swift
@@ -19,7 +19,8 @@ final class PFVideo: PFObject, PFSubclassing {
     @NSManaged var title: String?
     @NSManaged var url: URL?
     @NSManaged var file: PFFileObject?
-    
+    @NSManaged var observation: PFObservation?
+
     static func parseClassName() -> String {
         return "Video"
     }

--- a/EAO/Services/DataServices+Import.swift
+++ b/EAO/Services/DataServices+Import.swift
@@ -279,7 +279,7 @@ extension DataServices {
                 }
                 
                 let _ = DataServices.add(photo: object)
-                object.file?.getDataInBackground(block: { (data, error) in
+                object.photo?.getDataInBackground(block: { (data, error) in
                     if let data = data {
                         try? data.write(to: FileManager.directory.appendingPathComponent(remoteId, isDirectory: true))
                     }

--- a/EAO/Services/DataServices+Import.swift
+++ b/EAO/Services/DataServices+Import.swift
@@ -401,13 +401,12 @@ extension DataServices {
         
         do {
             let realm = try Realm()
-            let inspections = realm.objects(Inspection.self)
-            let metas = realm.objects(InspectionMeta.self)
-            
+            let inspections = realm.objects(Inspection.self).filter("isSubmitted = %@", true)
             try realm.write {
-                realm.deleteAll()
+                realm.delete(inspections)
             }
-        } catch let error {
+            
+        } catch let error{
             print("\(#function) Realm error: \(error.localizedDescription)")
             return false
         }

--- a/EAO/Services/DataServices+Import.swift
+++ b/EAO/Services/DataServices+Import.swift
@@ -34,7 +34,7 @@ extension DataServices {
             
             let inspection = Inspection()
             
-            inspection.id = pfInspection.id ?? UUID().uuidString
+            inspection.id = pfInspection.objectId ?? UUID().uuidString
             inspection.userId = userID
             inspection.isSubmitted = true
             
@@ -74,12 +74,12 @@ extension DataServices {
      
      - Returns: true or false. False if there are any issues adding an object
      */
-    class func add(observation pfobservation: PFObservation) -> Bool {
+    class func add(observation pfobservation: PFObservation, inspectionId: String) -> Bool {
         
         do {
             let observation = Observation()
-            observation.id = pfobservation.id ?? UUID().uuidString
-            observation.inspectionId = pfobservation.inspectionId
+            observation.id = pfobservation.objectId ?? UUID().uuidString
+            observation.inspectionId = inspectionId
             observation.title = pfobservation.title
             observation.requirement = pfobservation.requirement
             observation.coordinate = pfobservation.coordinate?.toRealmCoordinate()
@@ -105,13 +105,17 @@ extension DataServices {
      
      - Returns: true or false. False if there are any issues adding an object
      */
-    class func add(photo pfPhoto: PFPhoto) -> Bool {
+    class func add(photo pfPhoto: PFPhoto, observationId: String) -> Bool {
 
+        guard let objectId = pfPhoto.objectId else {
+            return false
+        }
+        
         do {
             let photo = Photo()
             
-            photo.id = pfPhoto.id ?? "\(UUID().uuidString).jpeg"
-            photo.observationId = pfPhoto.observationId
+            photo.id = "\(objectId).jpeg"
+            photo.observationId = observationId
             photo.caption = pfPhoto.caption
             photo.timestamp = pfPhoto.timestamp
             photo.coordinate = pfPhoto.coordinate?.toRealmCoordinate()
@@ -136,11 +140,16 @@ extension DataServices {
      
      - Returns: true or false. False if there are any issues adding an object
      */
-    class func add(photoThumb pfPhotoThumb: PFPhotoThumb) -> Bool {
+    class func add(photoThumb pfPhotoThumb: PFPhotoThumb, observationId: String) -> Bool {
+        
+        guard let objectId = pfPhotoThumb.objectId else {
+            return false
+        }
+
         do {
             let photoThumb = PhotoThumb()
-            photoThumb.id = pfPhotoThumb.id ?? "\(UUID().uuidString).jpeg"
-            photoThumb.observationId = pfPhotoThumb.observationId
+            photoThumb.id = "\(objectId).jpeg"
+            photoThumb.observationId = observationId
             photoThumb.index = pfPhotoThumb.index?.intValue ?? 0
             photoThumb.originalType = pfPhotoThumb.originalType
             
@@ -163,13 +172,17 @@ extension DataServices {
      
      - Returns: true or false. False if there are any issues adding an object
      */
-    class func add(audio pfAudio: PFAudio) -> Bool {
+    class func add(audio pfAudio: PFAudio, observationId: String) -> Bool {
+        
+        guard let objectId = pfAudio.objectId else {
+            return false
+        }
+
         do {
             let audio = Audio()
             
-            audio.id = pfAudio.id ?? "\(UUID().uuidString).mp4a"
-            audio.observationId = pfAudio.observationId
-            audio.inspectionId = pfAudio.inspectionId
+            audio.id = "\(objectId).mp4a"
+            audio.observationId = observationId
             audio.index = pfAudio.index?.intValue ?? 0
             audio.notes = pfAudio.notes
             audio.title = pfAudio.title
@@ -195,13 +208,17 @@ extension DataServices {
      
      - Returns: true or false. False if there are any issues adding an object
      */
-    class func add(video pfVideo: PFVideo) -> Bool {
+    class func add(video pfVideo: PFVideo, observationId: String) -> Bool {
+        
+        guard let objectId = pfVideo.objectId else {
+            return false
+        }
+
         do {
             let video = Video()
             
-            video.id = pfVideo.id ?? "\(UUID().uuidString).mp4"
-            video.observationId = pfVideo.observationId
-            video.inspectionId = pfVideo.inspectionId
+            video.id = "\(objectId).mp4"
+            video.observationId = observationId
             video.index = pfVideo.index?.intValue ?? 0
             video.notes = pfVideo.notes
             video.title = pfVideo.title
@@ -237,7 +254,8 @@ extension DataServices {
             return
         }
         
-        observationQuery.whereKey("inspectionId", equalTo: inspectionId)
+        let inspection = PFInspection(withoutDataWithObjectId: inspectionId)
+        observationQuery.whereKey("inspection", equalTo: inspection)
         observationQuery.findObjectsInBackground(block: { (observations, error) in
             
             guard let observations = observations as? [PFObservation], observations.count > 0 else {
@@ -246,11 +264,11 @@ extension DataServices {
             }
             
             for observation in observations {
-                guard let observationId = observation.id else {
+                guard let observationId = observation.objectId else {
                     continue
                 }
                 
-                let _ = DataServices.add(observation: observation)
+                let _ = DataServices.add(observation: observation, inspectionId: inspectionId)
                 self.fetchPhotos(for: observationId, completion: { (result) in
                     self.fetchPhotoThumbs(for: observationId, completion: { (result) in
                         self.fetchAudios(for: observationId, completion: { (result) in
@@ -271,17 +289,18 @@ extension DataServices {
             return
         }
         
-        query.whereKey("observationId", equalTo: observationId)
+        let observation = PFObservation(withoutDataWithObjectId: observationId)
+        query.whereKey("observation", equalTo: observation)
         query.findObjectsInBackground(block: { (array, error) in
             for object in array as? [PFPhoto] ?? [] {
-                guard let remoteId = object.id else {
+                guard let remoteId = object.objectId else {
                     continue
                 }
                 
-                let _ = DataServices.add(photo: object)
+                let _ = DataServices.add(photo: object, observationId: observationId)
                 object.photo?.getDataInBackground(block: { (data, error) in
                     if let data = data {
-                        try? data.write(to: FileManager.directory.appendingPathComponent(remoteId, isDirectory: true))
+                        try? data.write(to: FileManager.directory.appendingPathComponent("\(remoteId).jpeg", isDirectory: false))
                     }
                 })
             }
@@ -296,17 +315,18 @@ extension DataServices {
             return
         }
         
-        query.whereKey("observationId", equalTo: observationId)
+        let observation = PFObservation(withoutDataWithObjectId: observationId)
+        query.whereKey("observation", equalTo: observation)
         query.findObjectsInBackground(block: { (array, error) in
             for object in array as? [PFPhotoThumb] ?? [] {
-                guard let remoteId = object.id else {
+                guard let remoteId = object.objectId else {
                     continue
                 }
                 
-                let _ = DataServices.add(photoThumb: object)
+                let _ = DataServices.add(photoThumb: object, observationId: observationId)
                 object.file?.getDataInBackground(block: { (data, error) in
                     if let data = data {
-                        try? data.write(to: FileManager.directory.appendingPathComponent(remoteId, isDirectory: true))
+                        try? data.write(to: FileManager.directory.appendingPathComponent("\(remoteId).jpeg", isDirectory: false))
                     }
                 })
             }
@@ -321,17 +341,18 @@ extension DataServices {
             return
         }
         
-        query.whereKey("observationId", equalTo: observationId)
+        let observation = PFObservation(withoutDataWithObjectId: observationId)
+        query.whereKey("observation", equalTo: observation)
         query.findObjectsInBackground(block: { (array, error) in
             for object in array as? [PFAudio] ?? [] {
-                guard let remoteId = object.id else {
+                guard let remoteId = object.objectId else {
                     continue
                 }
                 
-                let _ = DataServices.add(audio: object)
+                let _ = DataServices.add(audio: object, observationId: observationId)
                 object.file?.getDataInBackground(block: { (data, error) in
                     if let data = data {
-                        try? data.write(to: FileManager.directory.appendingPathComponent(remoteId, isDirectory: true))
+                        try? data.write(to: FileManager.directory.appendingPathComponent("\(remoteId).mp4a", isDirectory: false))
                     }
                 })
             }
@@ -346,17 +367,18 @@ extension DataServices {
             return
         }
         
-        query.whereKey("observationId", equalTo: observationId)
+        let observation = PFObservation(withoutDataWithObjectId: observationId)
+        query.whereKey("observation", equalTo: observation)
         query.findObjectsInBackground(block: { (array, error) in
             for object in array as? [PFVideo] ?? [] {
-                guard let remoteId = object.id else {
+                guard let remoteId = object.objectId else {
                     continue
                 }
                 
-                let _ = DataServices.add(video: object)
+                let _ = DataServices.add(video: object, observationId: observationId)
                 object.file?.getDataInBackground(block: { (data, error) in
                     if let data = data {
-                        try? data.write(to: FileManager.directory.appendingPathComponent(remoteId, isDirectory: true))
+                        try? data.write(to: FileManager.directory.appendingPathComponent("\(remoteId).mp4", isDirectory: false))
                     }
                 })
             }
@@ -372,9 +394,11 @@ extension DataServices {
         
         do {
             let realm = try Realm()
-            let inspections = realm.objects(Inspection.self).filter("isSubmitted = %@", true)
+            let inspections = realm.objects(Inspection.self)
+            let metas = realm.objects(InspectionMeta.self)
+            
             try realm.write {
-                realm.delete(inspections)
+                realm.deleteAll()
             }
         } catch let error {
             print("\(#function) Realm error: \(error.localizedDescription)")

--- a/EAO/Services/DataServices+Import.swift
+++ b/EAO/Services/DataServices+Import.swift
@@ -31,9 +31,17 @@ extension DataServices {
         }
         
         do {
-            
+            let realm = try Realm()
+
+            //don't add existing local inspections
+            if let localId = pfInspection["localId"] {
+                let inspection = realm.objects(Inspection.self).filter("id in %@", [localId]).first
+                if inspection != nil {
+                    return false
+                }
+            }
+
             let inspection = Inspection()
-            
             inspection.id = pfInspection.objectId ?? UUID().uuidString
             inspection.userId = userID
             inspection.isSubmitted = true
@@ -54,7 +62,6 @@ extension DataServices {
             
             inspection.meta = doc
             
-            let realm = try Realm()
             try realm.write {
                 realm.add(inspection, update: true)
                 realm.add(doc, update: true)

--- a/EAO/Services/ParseUploadOperation.swift
+++ b/EAO/Services/ParseUploadOperation.swift
@@ -29,7 +29,8 @@ class InspectionUploadOperation: AsyncOperation {
         }
 
         let pfInspection = inspection.createParseObject()
-        
+        pfInspection["isActive"] = true     // Must be set else it wont show up in the Web UI.
+
         pfInspection.saveInBackground(block: { (status, error) in
 
             var operations = [Operation]()

--- a/EAO/Services/ParseUploadOperation.swift
+++ b/EAO/Services/ParseUploadOperation.swift
@@ -23,7 +23,7 @@ class InspectionUploadOperation: AsyncOperation {
     
     override func execute() {
         
-        guard let inspection: Inspection = DataServices.fetch(for: objectId) else {
+        guard let inspection: Inspection = DataServices.fetch(for: objectId), let teamID = inspection.teamID else {
             self.finished()
             return
         }
@@ -34,7 +34,7 @@ class InspectionUploadOperation: AsyncOperation {
         }
         
         pfInspection.isActive = NSNumber(value: true)     // Must be set else it wont show up in the Web UI.
-        pfInspection.team = PFTeam(withoutDataWithObjectId: "En8opj65uJ")
+        pfInspection.team = PFTeam(withoutDataWithObjectId: teamID)
         pfInspection.saveInBackground(block: { (status, error) in
 
             var operations = [Operation]()

--- a/EAO/Settings.swift
+++ b/EAO/Settings.swift
@@ -8,7 +8,7 @@
 
 struct Settings {
     
-    static let REALM_SCHEMA_NUMBER: UInt64 = 3
+    static let REALM_SCHEMA_NUMBER: UInt64 = 4
     static var shouldRotate = false
     
     static var formatter: DateFormatter {

--- a/EAO/UI/ImageGalleryCollection/ChooseImageViewController.swift
+++ b/EAO/UI/ImageGalleryCollection/ChooseImageViewController.swift
@@ -69,7 +69,8 @@ class ChooseImageViewController: UIViewController {
         closeVC()
     }
 
-    @objc func sent() {}
+    @objc func sent() {
+    }
 
     @objc func appWillEnterForeground() {
         if self.images.count != AssetManager.sharedInstance.getPHAssetImages().count {

--- a/EAO/UI/Inspections/InspectionFormController.swift
+++ b/EAO/UI/Inspections/InspectionFormController.swift
@@ -62,6 +62,7 @@ final class InspectionFormController: UIViewController {
         if segue.identifier == InspectionFormController.addNewElementSegueID, let destinationVC = segue.destination as? NewObservationElementFormViewController {
             destinationVC.observation = nil
             destinationVC.inspection = inspection
+            destinationVC.isReadOnly = isReadOnly
         }
         
         if segue.identifier == InspectionFormController.editElementSegueID, let destinationVC = segue.destination as? NewObservationElementFormViewController, let index = tableView.indexPathForSelectedRow?.row, index < observations.count {

--- a/EAO/UI/Inspections/InspectionsController.swift
+++ b/EAO/UI/Inspections/InspectionsController.swift
@@ -205,7 +205,7 @@ final class InspectionsController: UIViewController, CLLocationManagerDelegate {
 	}
 	
 	// Use this method to put an inspection from 'In Progress' to 'Submitted'
-	public func moveToSubmitted(inspection: Inspection?) {
+	private func moveToSubmitted(inspection: Inspection?) {
 
         guard let inspection = inspection, let idx = inspections.draft.index(of: inspection)  else {
             return
@@ -352,6 +352,7 @@ final class InspectionsController: UIViewController, CLLocationManagerDelegate {
             self.isBeingUploaded = false
             self.indicator.alpha = 0
             self.loadInspections()
+            self.moveToSubmitted(inspection: inspection)
         }
     }
 

--- a/EAO/UI/Inspections/NewObservationElementFormViewController.swift
+++ b/EAO/UI/Inspections/NewObservationElementFormViewController.swift
@@ -712,14 +712,19 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
         
         let indexRow = indexPath.row
         let statics = STATIC_CELLS_COUNT - 1
-        if indexRow < statics {return}
         let i = indexRow - STATIC_CELLS_COUNT
-        if i < 0 {return}
+        guard indexRow >= statics else {
+            return
+        }
+        guard i >= 0 else {
+            return
+        }
         if i < storedPhotos.count {
             
             let current = storedPhotos[i]
-            
-            if current.originalType == nil {return}
+            if current.originalType == nil {
+                return
+            }
             
             if current.originalType == "video" {
                 showPreviewOfVideo(index: storedPhotos[i].index)

--- a/EAO/UI/Inspections/NewObservationElementFormViewController.swift
+++ b/EAO/UI/Inspections/NewObservationElementFormViewController.swift
@@ -230,6 +230,7 @@ class NewObservationElementFormViewController: UIViewController {
             let description = "Your new text changes and new media loaded from the gallery will not be saved"
             showWarningAlert(title: title, description: description, yesButtonTapped: {
                 self.deleteNewPhotoAssets()
+                self.close()
             }) {
             }
         }

--- a/EAO/UI/Inspections/NewObservationElementFormViewController.swift
+++ b/EAO/UI/Inspections/NewObservationElementFormViewController.swift
@@ -151,14 +151,12 @@ class NewObservationElementFormViewController: UIViewController {
         coordinator.animate(alongsideTransition: nil) { _ in
             self.collectionView.reloadData()
             if UIDevice.current.orientation.isLandscape {
-                print("Landscape")
                 if self.isIpad() == false {
                     self.navBarHeight.constant = 0
                     self.saveButton.isHidden = true
                     self.cancelButton.isHidden = true
                 }
             } else {
-                print("Portrait")
                 self.navBarHeight.constant = 75
                 self.saveButton.isHidden = false
                 self.cancelButton.isHidden = false
@@ -218,18 +216,22 @@ class NewObservationElementFormViewController: UIViewController {
         if isReadOnly {
             self.mediaHeight.constant = 0
             self.mediaContainer.alpha = 0
+            saveButton.isHidden = true
         }
         self.containerHeight.constant = self.view.frame.height - 40
     }
     
     // MARK: ACTIONS
     @IBAction func cancelAction(_ sender: Any) {
-        let title = "Are you sure?"
-        let description = "Your new text changes and new media loaded from the gallery will not be saved"
-        showWarningAlert(title: title, description: description, yesButtonTapped: {
-            self.deleteNewPhotoAssets()
+        if isReadOnly {
             self.close()
-        }) {
+        } else {
+            let title = "Are you sure?"
+            let description = "Your new text changes and new media loaded from the gallery will not be saved"
+            showWarningAlert(title: title, description: description, yesButtonTapped: {
+                self.deleteNewPhotoAssets()
+            }) {
+            }
         }
     }
     

--- a/EAO/UI/Inspections/NewObservationElementFormViewController.swift
+++ b/EAO/UI/Inspections/NewObservationElementFormViewController.swift
@@ -33,13 +33,15 @@ class NewObservationElementFormViewController: UIViewController {
     static let segueShowImageGallery = "showImageGallery"
     static let segueShowVideoGallery = "showVideoGallery"
     static let segueShowAudioRecorder = "showAudioRecorder"
-
+    
     // MARK: COMPUTED VARIABLES
     var storedPhotos = [PhotoThumb]() {
         didSet {
             self.collectionView.reloadData()
         }
     }
+    // new photos added from device camera
+    var newPhotos = [(PhotoThumb, Photo)]()
     
     var isValid: Bool {
         if elementTitle != "" {
@@ -59,13 +61,13 @@ class NewObservationElementFormViewController: UIViewController {
             }
         }
     }
-
+    
     var storedAudios = [Audio]() {
         didSet {
             self.collectionView.reloadData()
         }
     }
-
+    
     var showingVideoPreview: Bool = false {
         didSet {
             if showingVideoPreview {
@@ -83,7 +85,7 @@ class NewObservationElementFormViewController: UIViewController {
             return 5
         }
     }
-
+    
     // MARK: VARIABLES
     var playingAudio: Bool = false
     var audioPlayer: AVAudioPlayer!
@@ -96,7 +98,7 @@ class NewObservationElementFormViewController: UIViewController {
     var elementoldDescription: String = ""
     var elementnewDescription: String = ""
     var currentCoordinatesString: String? = nil
-
+    
     let separator = "\n********\n"
     
     var uniqueButtonID = 0
@@ -104,19 +106,19 @@ class NewObservationElementFormViewController: UIViewController {
     
     var inspection: Inspection!
     var observation: Observation!
-
+    
     var currForm: MiFormManager?
-
+    
     var isReadOnly: Bool = false
-
+    
     // MARK: CONSTANTS
     var galleryManager = GalleryManager()
     let locationManager = CLLocationManager()
     var currentLocation: CLLocation?
-
+    
     // MARK: View did load
     override func viewDidLoad() {
-
+        
         super.viewDidLoad()
         lockdown()
         
@@ -129,7 +131,7 @@ class NewObservationElementFormViewController: UIViewController {
         setupView()
         unlock()
     }
-
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         updateImageResults()
@@ -140,11 +142,11 @@ class NewObservationElementFormViewController: UIViewController {
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         appDelegate.shouldRotate = false
     }
-
+    
     // when device rotates, reload collection view to re set the rizes of the cells
     // then hide or show nav bar
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
-
+        
         super.viewWillTransition(to: size, with: coordinator)
         coordinator.animate(alongsideTransition: nil) { _ in
             self.collectionView.reloadData()
@@ -164,9 +166,9 @@ class NewObservationElementFormViewController: UIViewController {
             self.collectionView.reloadData()
         }
     }
-
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-
+        
         if segue.identifier == NewObservationElementFormViewController.segueShowAudioRecorder, let destinationVC = segue.destination as? AudioRecorderViewController {
             
             destinationVC.inspectionID = inspection.id
@@ -209,7 +211,7 @@ class NewObservationElementFormViewController: UIViewController {
             return false
         }
     }
-
+    
     func setupView() {
         roundContainer(view: mediaContainer.layer)
         styleContainer(view: mediaContainer.layer)
@@ -222,7 +224,10 @@ class NewObservationElementFormViewController: UIViewController {
     
     // MARK: ACTIONS
     @IBAction func cancelAction(_ sender: Any) {
-        showWarningAlert(title: "Are you sure?", description: "Your new text changes and new media loaded from the gallery will not be saved", yesButtonTapped: {
+        let title = "Are you sure?"
+        let description = "Your new text changes and new media loaded from the gallery will not be saved"
+        showWarningAlert(title: title, description: description, yesButtonTapped: {
+            self.deleteNewPhotoAssets()
             self.close()
         }) {
         }
@@ -244,15 +249,15 @@ class NewObservationElementFormViewController: UIViewController {
     @IBAction func theodoliteAction(_ sender: Any) {
         goToThedolite()
     }
-
+    
     @IBAction func recordAction(_ sender: Any) {
         goToRecord()
     }
-
+    
     @IBAction func videoAction(_ sender: Any) {
         goToVideoGallery()
     }
-
+    
     @IBAction func closePopUp(_ sender: Any) {
         if currForm != nil {
             enabledPopUp = false
@@ -262,90 +267,104 @@ class NewObservationElementFormViewController: UIViewController {
         stopPlayback()
         popUpContainer.layer.sublayers?.removeAll()
     }
-
+    
     @IBAction func closeVideoPopup(_ sender: Any) {
         closeVideoPrev()
         popUpContainer.layer.sublayers?.removeAll()
     }
-
+    
     func closeVideoPrev() {
-        if !showingVideoPreview {return}
+        guard showingVideoPreview else {
+            return
+        }
         videoPlayer.pause()
         videoPlayer = AVPlayer()
         popUpContainer.layer.sublayers?.removeAll()
         showingVideoPreview = false
         enabledPopUp = false
     }
-
+    
     // MARK: FUNCTIONS
     func close() {
         self.dismiss(animated: true, completion: nil)
     }
-
+    
     func saveAssets(assets: [PHAsset], currIndex: Int,  lastIndex: Int, completion: @escaping () -> Void) {
+        
         if currIndex > lastIndex {
             return completion()
         }
+        
         var selectedAssets = assets
-        let asset = selectedAssets.first
-
-        if asset?.mediaType == .video {
+        guard let asset = selectedAssets.first else {
+            return completion()
+        }
+        let observationID = self.observation.id
+        
+        if asset.mediaType == .video {
             // if asset is video...
-            AssetManager.sharedInstance.getVideoFromAsset(phAsset: asset!, completion: { (avAsset) in
+            AssetManager.sharedInstance.getVideoFromAsset(phAsset: asset, completion: { (avAsset) in
                 // get url of asset, needed to generate thumbnail
-                asset?.getURL(completionHandler: { (videoURL) in
-                    if videoURL != nil {
-                        let thumbnail = AssetManager.sharedInstance.getThumbnailForVideo(url: videoURL! as NSURL)
-                        DataServices.saveVideo(avAsset: avAsset, thumbnail: thumbnail!, index: currIndex, observationID: self.observation.id, description: "**Video Loaded From Gallery**", completion: { (success) in
-                            if success {
-                                selectedAssets.removeFirst()
-                                self.saveAssets(assets: selectedAssets, currIndex: (currIndex + 1), lastIndex: lastIndex, completion: completion)
-                            } else {
-                                 return completion()
-                            }
-                        })
-                    } else {
+                asset.getURL(completionHandler: { (videoURL) in
+                    guard   let videoURL = videoURL,
+                            let thumbnail = AssetManager.sharedInstance.getThumbnailForVideo(url: videoURL as NSURL) else {
                         return completion()
                     }
+                    
+                    DataServices.saveVideo(avAsset: avAsset, thumbnail: thumbnail, index: currIndex, observationID: observationID, description: "**Video Loaded From Gallery**", completion: { (success) in
+                        if success {
+                            selectedAssets.removeFirst()
+                            DispatchQueue.main.async {
+                                self.saveAssets(assets: selectedAssets, currIndex: (currIndex + 1), lastIndex: lastIndex, completion: completion)
+                            }
+                        } else {
+                            return completion()
+                        }
+                    })
+                    
                 })
             })
         } else {
             // if asset is image:
-            AssetManager.sharedInstance.getOriginal(phAsset: asset!) { (img) in
-                DataServices.savePhoto(image: img, index: currIndex, location: asset?.location, observationID: self.observation.id, description: "**PHOTO LOADED FROM GALLERY**", completion: { (success) in
-                    if success {
-                        // successful? Remove last asset from array and call saveAssets recursively
-                        selectedAssets.removeFirst()
+            AssetManager.sharedInstance.getOriginal(phAsset: asset) { (img) in
+                if DataServices.savePhoto(image: img, index: currIndex, location: asset.location, observationID: observationID, description: "**PHOTO LOADED FROM GALLERY**") {
+                    // successful? Remove last asset from array and call saveAssets recursively
+                    selectedAssets.removeFirst()
+                    DispatchQueue.main.async {
                         self.saveAssets(assets: selectedAssets, currIndex: (currIndex + 1), lastIndex: lastIndex, completion: completion)
-                    } else {
-
-                        print("could not find image")
-                        return completion()
                     }
-                })
+                } else {
+                    print("could not find image")
+                    return completion()
+                }
             }
         }
     }
-
+    
     func saveObservation() {
-        if !isValid {self.unlock(); return}
-
+        guard isValid else {
+            self.unlock()
+            return
+        }
+        
         saveObservationAssets {
-             self.saveObservationDetails()
+            self.saveObservationDetails()
+            self.saveNewPhotos()
         }
     }
-
+    
     func saveObservationAssets(completion: @escaping () -> Void) {
+        
         var startingIndex = (storedPhotos.count - 1)
         if startingIndex < 0 {startingIndex = 0}
         let lastIndex = startingIndex + (multiSelectResult.count - 1)
-        print("from index: \(startingIndex), to \(lastIndex)")
+        print("saving bservation assets from index: \(startingIndex), to \(lastIndex)")
         saveAssets(assets: multiSelectResult, currIndex: startingIndex, lastIndex: lastIndex) {
             return completion()
         }
     }
-
-    func saveObservationDetails() {
+    
+    private func saveObservationDetails() {
         
         guard let realm = try? Realm() else {
             print("Unable open realm")
@@ -376,8 +395,8 @@ class NewObservationElementFormViewController: UIViewController {
         }
         self.unlock()
     }
-
-    func setUpObservationObject() {
+    
+    private func setUpObservationObject() {
         // if observation is not set, create it
         // otherwise autofill data
         if observation == nil {
@@ -389,7 +408,41 @@ class NewObservationElementFormViewController: UIViewController {
             autofill()
         }
     }
+    
+    /**
+     Save photos added from device camera
+     */
+    private func saveNewPhotos(){
+        
+        guard let realm = try? Realm() else {
+            print("Unable open realm")
+            return
+        }
+        do {
+            try realm.write {
+                for (newThumb, newPhoto) in newPhotos {
+                    realm.add(newThumb, update: true)
+                    realm.add(newPhoto, update: true)
+                }
+            }
+        } catch let error {
+            print("Realm exception \(error.localizedDescription)")
+        }
+    }
 
+    private func deleteNewPhotoAssets(){
+        
+        for (thumb, photo) in newPhotos {
+            let thumbPath = FileManager.directory.appendingPathComponent(thumb.id, isDirectory: false)
+            let photoPath = FileManager.directory.appendingPathComponent(photo.id, isDirectory: false)
+            do {
+                try FileManager.default.removeItem(at: thumbPath)
+                try FileManager.default.removeItem(at: photoPath)
+            } catch {
+            }
+        }
+    }
+    
     func autofill() {
         self.elementTitle = observation.title!
         self.elementRequirement = observation.requirement!
@@ -398,9 +451,8 @@ class NewObservationElementFormViewController: UIViewController {
         self.load()
         self.isAutofilled = true
     }
-
+    
     func load() {
-        print("load")
         DataServices.getThumbnailsFor(observationID: observation.id) { (success, photos) in
             if success {
                 self.storedPhotos = photos!
@@ -412,21 +464,25 @@ class NewObservationElementFormViewController: UIViewController {
             }
         }
     }
-
+    
     func updateImageResults() {
         self.lockdown()
         let newResults = galleryManager.multiSelectResult
-        if newResults.count == 0 {self.unlock(); return}
+        guard newResults.count > 0 else {
+            self.unlock()
+            return
+        }
+        
         // Don't add duplicates
         for asset in newResults {
-            if !self.multiSelectResult.contains(asset) {
+            if self.multiSelectResult.contains(asset) == false {
                 self.multiSelectResult.append(asset)
             }
         }
         self.collectionView.reloadData()
         self.unlock()
     }
-
+    
     func styleContainer(view: CALayer) {
         view.borderColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.5).cgColor
         view.shadowOffset = CGSize(width: 0, height: 2)
@@ -434,21 +490,21 @@ class NewObservationElementFormViewController: UIViewController {
         view.shadowOpacity = 1
         view.shadowRadius = 3
     }
-
+    
     func roundContainer(view: CALayer) {
         view.cornerRadius = 8
     }
-
+    
     func circleContainer(view: CALayer, height: CGFloat) {
         view.cornerRadius = height/2
     }
-
+    
     func lockdown() {
         actIndicator.startAnimating()
         self.activityIndicatorContainer.alpha = 1
         self.view.isUserInteractionEnabled = false
     }
-
+    
     func unlock() {
         actIndicator.stopAnimating()
         self.activityIndicatorContainer.alpha = 0
@@ -469,7 +525,7 @@ class NewObservationElementFormViewController: UIViewController {
     }
     
     func goToVideoGallery() {
-        performSegue(withIdentifier: NewObservationElementFormViewController.segueShowAudioRecorder, sender: nil)
+        performSegue(withIdentifier: NewObservationElementFormViewController.segueShowVideoGallery, sender: nil)
     }
     
     func goToThedolite() {
@@ -506,7 +562,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
         names.append("NewDescriptionNewObservationCollectionViewCell")
         
         for name in names {
-            registerCell(name: name) 
+            registerCell(name: name)
         }
     }
     
@@ -529,7 +585,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
     func getDescriptionCell(indexPath: IndexPath) -> DescriptionNewObservationCollectionViewCell {
         return collectionView.dequeueReusableCell(forIndexPath: indexPath)
     }
-
+    
     func getNewDescriptionCell(indexPath: IndexPath) -> NewDescriptionNewObservationCollectionViewCell {
         return collectionView.dequeueReusableCell(forIndexPath: indexPath)
     }
@@ -549,7 +605,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
             return getCellsForEditing(indexPath: indexPath)
         }
     }
-
+    
     func getCellsForEditing(indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.row {
         case 0:
@@ -588,7 +644,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
             return cell
         }
     }
-
+    
     func getCellsForViewing(indexPath: IndexPath) -> UICollectionViewCell {
         switch indexPath.row {
         case 0:
@@ -622,7 +678,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
             return cell
         }
     }
-
+    
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         let width = collectionView.frame.width
         if !isReadOnly {
@@ -651,7 +707,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
             }
         }
     }
-
+    
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         
         let indexRow = indexPath.row
@@ -660,29 +716,26 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
         let i = indexRow - STATIC_CELLS_COUNT
         if i < 0 {return}
         if i < storedPhotos.count {
-
+            
             let current = storedPhotos[i]
-
+            
             if current.originalType == nil {return}
-
+            
             if current.originalType == "video" {
                 showPreviewOfVideo(index: storedPhotos[i].index)
             }
-
+            
             if current.originalType == "photo" {
-                for item in storedPhotos {
-                    print(item)
-                }
-                showPreviewOf(index: storedPhotos[i].index)
+                showPhotoPreview(for: storedPhotos[i].index)
             }
         } else if i - storedPhotos.count < multiSelectResult.count {
-            print("multiselect")
+            print("\(#function) multiselect")
         } else if i - storedPhotos.count - multiSelectResult.count < storedAudios.count {
-            print("audio")
+            print("\(#function) audio")
             playAudioAt(index: i - storedPhotos.count - multiSelectResult.count)
         }
     }
-
+    
     func playAudioAt(index: Int) {
         
         let audio = storedAudios[index]
@@ -691,7 +744,7 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
         let buttonStyleRed = MiButtonStyle(textColor: .white, bgColor: Colors.Red, height: 50, roundCorners: true)
         let textStyleL = LabelStyle(height: 100, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
         let textStyleS = LabelStyle(height: 50, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
-
+        
         if audio.title != nil {
             form.addLabel(name: "sounddesc", text: audio.title! , style: textStyleS)
         }
@@ -700,91 +753,90 @@ extension NewObservationElementFormViewController: UICollectionViewDelegate, UIC
         }
         form.addButton(name: "playAudio\(index)", title: "Play",style: buttonStyleBlue) {
             if !self.playingAudio, let data = audio.get() {
-                print(data.count)
                 self.playAudio(data: data)
             }
         }
-
+        
         form.addButton(name: "stop\(index)", title: "Stop", style: buttonStyleBlue) {
             self.stopPlayback()
         }
-
+        
         form.addButton(name: "closesoundplayback\(index)", title: "Close", style: buttonStyleRed) {
             self.enabledPopUp = false
             self.stopPlayback()
             form.remove(from: self.popUpContainer)
         }
-
+        
         self.enabledPopUp = true
         self.containerHeight.constant = 380
         self.currForm = form
         form.display(in: self.popUpContainer, on: self)
     }
-
+    
     func showPreviewOfVideo(index: Int) {
-
+        
         self.containerHeight.constant = self.view.frame.height - 200
-        DataServices.getVideoFor(observationID: observation.id, at: index) { (found, pfVideo) in
-            if found {
-                guard let assetURL = pfVideo?.getURL() else {return}
-                let avasset = AVAsset(url: assetURL)
-                let x = AVPlayerItem(asset: avasset)
-                self.videoPlayer = AVPlayer(playerItem: x)
-                let playerLayer = AVPlayerLayer(player: self.videoPlayer)
-                self.grayScreen.alpha = 1
-                self.popUpContainer.alpha = 1
-                self.containerHeight.constant = self.view.frame.height - 200
-                playerLayer.frame = self.popUpContainer.bounds
-                playerLayer.backgroundColor = UIColor.white.cgColor
-                self.showingVideoPreview = true
-                self.popUpContainer.layer.addSublayer(playerLayer)
-
-                self.videoPlayer.play()
+        
+        if let video = DataServices.getVideo(for: observation.id, at: index) {
+            guard let assetURL = video.getURL() else {
+                return
             }
+            let avasset = AVAsset(url: assetURL)
+            let x = AVPlayerItem(asset: avasset)
+            self.videoPlayer = AVPlayer(playerItem: x)
+            let playerLayer = AVPlayerLayer(player: self.videoPlayer)
+            self.grayScreen.alpha = 1
+            self.popUpContainer.alpha = 1
+            self.containerHeight.constant = self.view.frame.height - 200
+            playerLayer.frame = self.popUpContainer.bounds
+            playerLayer.backgroundColor = UIColor.white.cgColor
+            self.showingVideoPreview = true
+            self.popUpContainer.layer.addSublayer(playerLayer)
+            
+            self.videoPlayer.play()
         }
     }
-
-    func showPreviewOf(index: Int) {
-
+    
+    func showPhotoPreview(for index: Int) {
+        
         let form = MiFormManager()
         let style = MiButtonStyle(textColor: .white, bgColor: Colors.Blue, height: 50, roundCorners: true)
         let textStyleL = LabelStyle(height: 100, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
         let textStyleS = LabelStyle(height: 50, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
         let textStyleM = LabelStyle(height: 80, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
-
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
-        DataServices.getPhotoFor(observationID: observation.id, at: index) { (found, photo) in
-
-            if found {
-                let locationString = photo?.coordinate?.printableString() ?? ""
-
-                if let image = photo?.image {
-                    form.addImage(image: image)
-                }
-                form.addLabel(name: "caption", text: (photo?.caption)!, style: textStyleL)
-                form.addLabel(name: "piclocation", text: locationString, style: textStyleM)
-                form.addLabel(name: "date:", text: formatter.string(from: (photo?.timestamp)!), style: textStyleS)
-                form.addButton(name: "closeprev\(index)", title: "close", style: style, completion: {
-                    self.enabledPopUp = false
-                    form.remove(from: self.popUpContainer)
-                })
-                self.enabledPopUp = true
-                self.containerHeight.constant = self.view.frame.height - 40
-                self.currForm = form
-                form.display(in: self.popUpContainer, on: self)
+        
+        if let photo = DataServices.getPhoto(for: observation.id, at: index) {
+            let locationString = photo.coordinate?.printableString() ?? ""
+            
+            if let image = photo.image {
+                form.addImage(image: image)
             }
+            if let caption = photo.caption, caption.count > 0 {
+                form.addLabel(name: "caption", text: caption, style: textStyleL)
+            }
+            form.addLabel(name: "piclocation", text: locationString, style: textStyleM)
+            if let timestamp = photo.timestamp {
+                form.addLabel(name: "date:", text: Settings.formatter.string(from: timestamp), style: textStyleS)
+            }
+            form.addButton(name: "closeprev\(index)", title: "close", style: style, completion: {
+                self.enabledPopUp = false
+                form.remove(from: self.popUpContainer)
+            })
+            self.enabledPopUp = true
+            self.containerHeight.constant = self.view.frame.height - 40
+            self.currForm = form
+            form.display(in: self.popUpContainer, on: self)
         }
     }
 }
 
 // MARK: Collection view
 extension  NewObservationElementFormViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
     func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         
-// Local variable inserted by Swift 4.2 migrator.
-let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
-
+        // Local variable inserted by Swift 4.2 migrator.
+        let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
         imagePicker.dismiss(animated: true, completion: nil)
         let image = info[convertFromUIImagePickerControllerInfoKey(UIImagePickerController.InfoKey.originalImage)] as? UIImage
         promptImageDetails(image: image!)
@@ -797,15 +849,15 @@ let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
         let commonFieldStyle = MiTextFieldStyle(titleColor: Colors.Blue, inputColor: Colors.Blue, fieldBG: .white, bgColor: .white, height: 150, roundCorners: true)
         
         let commonButtonStyle = MiButtonStyle(textColor: .white, bgColor: Colors.Blue, height: 50, roundCorners: true)
-
+        
         let textStyleS = LabelStyle(height: 50, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
         let textStyleM = LabelStyle(height: 80, roundCorners: true, bgColor: UIColor.white, labelTextColor: Colors.Blue)
-
+        
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         let nowDate = Date()
         let nowDateString = formatter.string(from: nowDate)
-
+        
         let location = self.locationManager.location!
         let lat = round(num: location.coordinate.latitude, toPlaces: 5)
         let long = round(num: location.coordinate.longitude, toPlaces: 5)
@@ -815,28 +867,28 @@ let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
         form.addField(name: "details", title: "Caption", placeholder: "", type: .TextViewInput, inputType: .Text, style: commonFieldStyle)
         form.addLabel(name: "gpsstamp", text: locationString, style: textStyleM)
         form.addLabel(name: "datestamp", text: nowDateString, style: textStyleS)
+        
         form.addButton(name: "submit\(uniqueButtonID)", title: "Add", style: commonButtonStyle) {
+
             let results = form.getFormResults()
             var comments = ""
-            
-            if !results.isEmpty {
+            if results.isEmpty == false {
                 if let details = results["details"] {
                     comments = details
                 }
             }
-
+            
             // TODO:: Store nowDate
-            DataServices.savePhoto(image: image, index: self.storedPhotos.count, location: location, observationID: self.observation.id, description: comments, completion: { (done) in
-                if done {
-                    self.load()
-                    self.enabledPopUp = false
-                    form.remove(from: self.popUpContainer)
-                }
-            })
+            if let (thumbnail, photo) = DataServices.preparePhoto(image: image, index: self.storedPhotos.count, location: location, observationID: self.observation.id, description: comments) {
+                self.load()
+                self.enabledPopUp = false
+                form.remove(from: self.popUpContainer)
+                self.storedPhotos.append(thumbnail)
+                self.newPhotos.append(((thumbnail, photo)))
+            }
         }
         
         uniqueButtonID += 1
-        
         enabledPopUp = true
         self.containerHeight.constant = self.view.frame.height - 40
         self.currForm = form
@@ -846,7 +898,7 @@ let info = convertFromUIImagePickerControllerInfoKeyDictionary(info)
 
 extension NewObservationElementFormViewController: AVAudioPlayerDelegate {
     // Playback
-
+    
     func playback(url: URL) {
         if FileManager.default.fileExists(atPath: url.path) {
             if initPlay(url: url) {
@@ -856,14 +908,14 @@ extension NewObservationElementFormViewController: AVAudioPlayerDelegate {
             // error: could not find audio file
         }
     }
-
+    
     func stopPlayback() {
         if self.playingAudio {
             audioPlayer.stop()
             self.playingAudio = false
         }
     }
-
+    
     func initPlay(url: URL) -> Bool {
         do {
             audioPlayer = try AVAudioPlayer(contentsOf: url)
@@ -875,7 +927,7 @@ extension NewObservationElementFormViewController: AVAudioPlayerDelegate {
             return false
         }
     }
-
+    
     func playAudio(data: Data) {
         do {
             audioPlayer = try AVAudioPlayer(data: data)
@@ -887,7 +939,7 @@ extension NewObservationElementFormViewController: AVAudioPlayerDelegate {
             print("Error")
         }
     }
-
+    
     func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
         stopPlayback()
     }
@@ -895,10 +947,11 @@ extension NewObservationElementFormViewController: AVAudioPlayerDelegate {
 
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertFromUIImagePickerControllerInfoKeyDictionary(_ input: [UIImagePickerController.InfoKey: Any]) -> [String: Any] {
-	return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
+    return Dictionary(uniqueKeysWithValues: input.map {key, value in (key.rawValue, value)})
 }
 
 // Helper function inserted by Swift 4.2 migrator.
 fileprivate func convertFromUIImagePickerControllerInfoKey(_ input: UIImagePickerController.InfoKey) -> String {
-	return input.rawValue
+    return input.rawValue
 }
+

--- a/EAO/Video.swift
+++ b/EAO/Video.swift
@@ -38,7 +38,7 @@ extension Video: ParseFactory {
     
     func createParseObject() -> PFObject {
         
-        let object = PFAudio()
+        let object = PFVideo()
         // Do not set the properties: `id`, `observationId`, `inspectionId`.
         object.notes = self.notes
         if let urlString = self.url {

--- a/EAO/Video.swift
+++ b/EAO/Video.swift
@@ -39,9 +39,9 @@ extension Video: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFAudio()
-        object.id = self.id
-        object.observationId = self.observationId
-        object.inspectionId = self.inspectionId
+        // Do not set the `id` property.
+//        object.observationId = self.observationId
+//        object.inspectionId = self.inspectionId
         object.notes = self.notes
         if let urlString = self.url {
             object.url = URL(string: urlString)

--- a/EAO/Video.swift
+++ b/EAO/Video.swift
@@ -39,9 +39,7 @@ extension Video: ParseFactory {
     func createParseObject() -> PFObject {
         
         let object = PFAudio()
-        // Do not set the `id` property.
-//        object.observationId = self.observationId
-//        object.inspectionId = self.inspectionId
+        // Do not set the properties: `id`, `observationId`, `inspectionId`.
         object.notes = self.notes
         if let urlString = self.url {
             object.url = URL(string: urlString)

--- a/EAO/Video.swift
+++ b/EAO/Video.swift
@@ -24,12 +24,12 @@ final class Video: Object {
     }
     
     @objc func get() -> Data? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return try? Data(contentsOf: url)
     }
     
     @objc func getURL() -> URL? {
-        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: true)
+        let url = URL(fileURLWithPath: FileManager.directory.absoluteString).appendingPathComponent(id, isDirectory: false)
         return url
     }
 }

--- a/EAO/Video.swift
+++ b/EAO/Video.swift
@@ -12,7 +12,6 @@ final class Video: Object {
     
     @objc dynamic var id: String = "\(UUID().uuidString).mp4"
     @objc dynamic var observationId: String?
-    @objc dynamic var inspectionId: String?
     @objc dynamic var index: Int = 0
     @objc dynamic var notes: String?
     @objc dynamic var title: String?


### PR DESCRIPTION
Fixed #26 The relations are not preserved when synchronizing with the parse server:
- preserver relations Observations to Inspection, Photo/Video/Audio to Observations and Inspection to Team on uploading to the Parse server;
- updated download inspection flow to use Parse relations;

Fixed #27 When an inspection is synchronized it does not move the the submitted tab:
- inspection is moved to submitted tab once it's uploaded;

Fixed #28 The save button should not be active for a submitted inspection

Fixed #29 A photo or video should be presented on save only
- photos and other medias are not saved on cancelling observation changes

Other issues:
- fixed preview for photos;
- fixed saving and previewing videos;
- added proper action to open video gallery;
 